### PR TITLE
Restyle the contents to be collapsable

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,33 +1,24 @@
 # Table of contents
 
 * [Documentation](README.md)
-
-## Getting Started
-
-* [Installation](getting-started/installation.md)
-* [Quick Start](getting-started/quick-start.md)
-* [Configuration](getting-started/configuration.md)
-
-## The Basics
-
-* [Lifecycle](the-basics/lifecycle.md)
-* [Post Types](the-basics/post-types.md)
-* [WordPress Controllers](the-basics/wordpress-controllers.md)
-* [Routing](the-basics/routing.md)
-* [HTTP Responses](the-basics/http-responses.md)
-
-## Container
-
-* [Using the Container](container/using-the-container.md)
-* [Service Providers](container/service-providers.md)
-* [Facades](container/facades.md)
-
-## Misc
-
-* [Changelog](misc/changelog.md)
-* [Contributing](misc/contributing.md)
-* [Notable Mentions](misc/notable-mentions.md)
-* [Code of Conduct](misc/code-of-conduct.md)
-* [View on GitHub](https://github.com/Rareloop/lumberjack)
-* [Submit an issue](https://github.com/Rareloop/lumberjack/issues/new)
-
+* [Getting Started](getting-started/installation.md)
+  * [Installation](getting-started/installation.md)
+  * [Quick Start](getting-started/quick-start.md)
+  * [Configuration](getting-started/configuration.md)
+* [The Basics](the-basics/lifecycle.md)
+  * [Lifecycle](the-basics/lifecycle.md)
+  * [Post Types](the-basics/post-types.md)
+  * [WordPress Controllers](the-basics/wordpress-controllers.md)
+  * [Routing](the-basics/routing.md)
+  * [HTTP Responses](the-basics/http-responses.md)
+* [Container](container/using-the-container.md)
+  * [Using the Container](container/using-the-container.md)
+  * [Service Providers](container/service-providers.md)
+  * [Facades](container/facades.md)
+* [Misc](misc/changelog.md)
+  * [Changelog](misc/changelog.md)
+  * [Contributing](misc/contributing.md)
+  * [Notable Mentions](misc/notable-mentions.md)
+  * [Code of Conduct](misc/code-of-conduct.md)
+  * [View on GitHub](https://github.com/Rareloop/lumberjack)
+  * [Submit an issue](https://github.com/Rareloop/lumberjack/issues/new)


### PR DESCRIPTION
By converting the menu to be a single list with indented children GitBook will style the menu to have collapsable sections