### PR TITLE
Update service-providers.md class boot to function boot

### DIFF
--- a/container/service-providers.md
+++ b/container/service-providers.md
@@ -55,7 +55,7 @@ use Rareloop\Lumberjack\Providers\ServiceProvider;
 class OptionPagesProvider extends ServiceProvider
 {
     // Dependency inject Config from the container
-    public class boot(Config $config)
+    public function boot(Config $config)
     {
         $optionPages = $config->get('option-pages');
 


### PR DESCRIPTION
Example service provider code now correctly has function boot() instead of class boot()