### PR TITLE
Add documentation for Facades available in Lumberjack

### DIFF
--- a/container/facades.md
+++ b/container/facades.md
@@ -38,3 +38,45 @@ class Log extends AbstractFacade
 }
 ```
 
+## Available Facades
+
+The following Facades are already registered within Lumberjack.
+
+* [Config](facades.md#Config)
+* [Log](facades.md#Log)
+* [Router](facades.md#Router)
+* [Session](facades.md#Session)
+
+### Config
+
+The `config` facade allows you to get and set values from your config.
+
+```php
+$value = Config::get('app.environment');
+```
+
+Config is also available as a [Helper](https://docs.lumberjack.rareloop.com/the-basics/helpers#config)
+
+### Log
+
+The `log` facade allows you to use the [PSR-3](https://www.php-fig.org/psr/psr-3/) Logger [Monolog](https://github.com/Seldaek/monolog).
+
+```php
+$value = Log::warning('oops');
+```
+
+### Router
+
+The `router` facade allows you to define named routes.
+
+See [Creating Routes](https://docs.lumberjack.rareloop.com/the-basics/routing#creating-routes) for more information.
+
+### Session
+
+The `session` facade allows you to retrieve and store data in the current session.
+
+```php
+$name = Session::get('name');
+```
+
+Session is also available as a [Helper](https://docs.lumberjack.rareloop.com/the-basics/helpers#session)


### PR DESCRIPTION
There are 4 facades which are already available in Lumberjack. These have not been directly documentation, though Router, for example, is referenced in the Routing section of the docs.

This addition to the documentation gives a quick reference to see what Facades are available in the same way that helpers are documented.