### PR TITLE
Fixed toArray method return type

### DIFF
--- a/the-basics/view-models.md
+++ b/the-basics/view-models.md
@@ -230,7 +230,7 @@ class MediaCardsViewModel extends ViewModel
      */
     public function toArray(): array
     {
-        return $this->cards();
+        return $this->cards->toArray();
     }
 }
 ```


### PR DESCRIPTION
Example toArray method incorrectly returned a Collection instead of an array